### PR TITLE
Require password to be prompted at runtime so it isn't saved on disk

### DIFF
--- a/rubygems.rb
+++ b/rubygems.rb
@@ -39,7 +39,13 @@ ACCESS_TOKEN = rubygems.github_token
 RUBY_TOOLBOX_BASE_URL = "https://www.ruby-toolbox.com/projects/"
 RATING_XPATH = "//div[@class='teaser-bar']//li[last()-1]//a"
 
-github = Github.new basic_auth: "#{rubygems.github_account}:#{rubygems.github_password}"
+`stty -echo`
+print 'Github Password (not stored): '
+github_password = gets.chomp
+`stty echo`
+puts ""
+
+github = Github.new basic_auth: "#{rubygems.github_account}:#{github_password}"
 
 versions = Gems.versions GEM_NAME
 oga_info = Gems.info GEM_NAME


### PR DESCRIPTION
- password is requested at runtime (password characters not echoed on screen)
- avoids processes like Dropbox from recording/transmitting our Github password
